### PR TITLE
Fixed bug related to dumping json to arff

### DIFF
--- a/arff_parser.py
+++ b/arff_parser.py
@@ -182,7 +182,6 @@ def makeArff(filename,handle,opts):
 	dataOut= []
 	attributesOut=[]
 	relation = filename.split(".")[0] 
-	outfile = open(handle,'w')
 	with open(filename) as data_file: 
 		dataIn = json.load(data_file)		
 	for entry in dataIn["data"]:			
@@ -195,7 +194,7 @@ def makeArff(filename,handle,opts):
 			values.append(entry[value])
 		dataOut.append(values)
 		attributesOut.append(attributes)	
-	arff.dump(outfile, dataOut, relation=relation, names=attributesOut[0])
+	arff.dump(handle, dataOut, relation=relation, names=attributesOut[0])
 
 def show_schema(schema):
 	"""debug"""


### PR DESCRIPTION
The arff library takes a filename(string) as input and not a file
handle. Fixed by removing the file handle and passing the filename

The converter has a bug that it does not convert json to arff properly
This needs to be fixed further

Signed-off-by: Sateesh Kavuri skavuri@yodlee.com
